### PR TITLE
update for ocxl_event_irq struct.  changed id to handle.  

### DIFF
--- a/libocxl/libocxl.c
+++ b/libocxl/libocxl.c
@@ -358,7 +358,7 @@ static int _handle_interrupt(struct ocxl_afu *afu, uint8_t data_is_valid)
 	//afu->events[i]->header.size = size;
 	//afu->events[i]->header.process_element = afu->context; // might not need this
 	afu->events[i]->irq.irq = irq->irq;  // which came in and matched irq
-	afu->events[i]->irq.id = addr;  // which came in and matched irq
+	afu->events[i]->irq.handle = addr;  // which came in and matched irq
 	afu->events[i]->irq.count = 1;  
 	// should we store data from an interrupt d at the info pointer?
 	// afu->events[i]->irq.flags = cmd_flag;

--- a/libocxl/libocxl.h
+++ b/libocxl/libocxl.h
@@ -102,7 +102,7 @@ typedef enum {
  */
 typedef struct {
   uint16_t irq;
-  uint64_t id;
+  uint64_t handle;
   void *info;
   uint64_t count;
 } ocxl_event_irq;


### PR DESCRIPTION
The interrupt function has been verified in both simulation and hardware. 
The irq_event data structure in OCSE/libocxl matches the libocxl now. 